### PR TITLE
Add credential to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,11 +124,7 @@ export LANDING_PATH="./data/landing/"
 export STAGING_PATH="./data/staging/main.csv"
 ```
 
-If you're using a `.env` file, don't forget to run:
-
-```bash
-source .env
-```
+If you're using a `.env` file, keep it in the root of this repository as best practice.
 
 ### CLI / Usage
 

--- a/src/ecmwf_client_new/request_executor.py
+++ b/src/ecmwf_client_new/request_executor.py
@@ -8,7 +8,9 @@ from ..setup import PipelineConfig
 from ..storage import StorageManager, RetrievalMeta, RetrievalTicket
 from ..setup.logging import ecmwf_log
 from .request_builder import ECMWFRequestsBuilder
+from dotenv import load_dotenv
 
+load_dotenv()
 
 class ECMWFRequestsExecutor:
     """ TODO """


### PR DESCRIPTION
This pull request does the following:
- Added descriptions of using the ECMWF environment variables to the readme file
- Removed description of sourcing env variables in terminal since it is negligible due to the use of `load_dotenv` in the code.
- Added `load_dotenv` to the `request_builder.py` ensuring`ECMWFService` is able to access any environment variables for credentials.

Functionality is tested locally and shows that the request is authorized at ECMWF. 