### PR TITLE
Fix default config path (minor fix)

### DIFF
--- a/src/setup/config/defaults.py
+++ b/src/setup/config/defaults.py
@@ -7,6 +7,7 @@ ALLOWED_RETRIEVAL_MODES = ["point", "grid"]
 DEFAULT_FORMAT = "netcdf"
 ALLOWED_FORMATS = ["grib2", "netcdf"]
 
+DEFAULT_CONFIG_PATH = "./config/config_hres.yml"
 DEFAULT_LOG_PATH = "./logs/DEBUG.log"
 DEFAULT_QUERY_PATH = "./queries/default.json"
 DEFAULT_LANDING_PATH = "./data/landing/"

--- a/src/setup/config/loader.py
+++ b/src/setup/config/loader.py
@@ -6,11 +6,12 @@ import yaml
 from dotenv import load_dotenv
 
 from .schema import PipelineConfig
+from .defaults import DEFAULT_CONFIG_PATH
 
 
 def load_config(args: argparse.Namespace = None) -> PipelineConfig:
     # Load YAML configuration
-    path = Path(args.config_path) if args and args.config_path else Path(__file__).parent.parent.parent.parent / "config" / "config.yml"
+    path: Path = Path(args.config_path) if args and args.config_path else Path(DEFAULT_CONFIG_PATH)
     with path.open("r") as f:
         config_dict = yaml.safe_load(f)
 

--- a/src/setup/config/loader.py
+++ b/src/setup/config/loader.py
@@ -10,10 +10,18 @@ from .defaults import DEFAULT_CONFIG_PATH
 
 
 def load_config(args: argparse.Namespace = None) -> PipelineConfig:
-    # Load YAML configuration
-    path: Path = Path(args.config_path) if args and args.config_path else Path(DEFAULT_CONFIG_PATH)
-    with path.open("r") as f:
-        config_dict = yaml.safe_load(f)
+    # Load YAML configuration if "retrieval" command is used
+    if args and args.command == "retrieval":
+        if hasattr(args, "config_path") and args.config_path:
+            path: Path = Path(args.config_path)
+        else:
+            path = Path(DEFAULT_CONFIG_PATH)
+
+        with path.open("r") as f:
+            config_dict = yaml.safe_load(f)
+
+    else:
+        config_dict = {}
 
     # Load environment variables
     load_dotenv(override=True)


### PR DESCRIPTION
The default value for the config path wasn't valid which means no --config-path argument resulted in an error. 